### PR TITLE
Add i18n support

### DIFF
--- a/lib/en.json
+++ b/lib/en.json
@@ -1,0 +1,13 @@
+{
+  "help": "HELP",
+  "exit": "EXIT",
+  "error": "ERROR:",
+  "completed": "[COMPLETED]",
+  "solution-incorrect": "YOUR SOLUTION IS NOT CORRECT!",
+  "unrecognized-command": "unrecognized command:",
+  "no-adventure-selected": "No adventure is currently selected. Select an adventure from the menu.",
+  "solution-correct": "YOUR SOLUTION IS CORRECT!",
+  "no-solution": "No reference solution available for this adventure.",
+  "no-run-function": "This problem doesn't have a .run function.",
+  "no-verify-function": "This problem doesn't have a .verify function yet!"
+}

--- a/lib/help.js
+++ b/lib/help.js
@@ -3,7 +3,9 @@ var split = require('split');
 var through = require('through2');
 
 module.exports = function (opts) { 
-    fs.createReadStream(__dirname + '/usage.txt')
+    var usage = opts.usage || fs.createReadStream(__dirname + '/usage.txt')
+    usage
+        .pipe(split())
         .pipe(through(function (buf, enc, next) {
             var line = buf.toString('utf8')
                 .replace(/\$COMMAND/g, opts.command)

--- a/lib/lang.js
+++ b/lib/lang.js
@@ -1,0 +1,9 @@
+var lang = require('./en.json');
+
+module.exports = function (i18n) {
+  i18n = i18n || {}
+  Object.keys(lang).forEach(function (key) {
+    lang[key] = i18n[key] || lang[key]
+  })
+  return lang
+}

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -1,6 +1,7 @@
 var tmenu = require('terminal-menu');
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
+var vw = require('visualwidth')
 var showHelp = require('./help.js');
 
 module.exports = function (opts) {
@@ -13,6 +14,8 @@ module.exports = function (opts) {
       fg: opts.fg || 'white'
     });
     
+    var i18n = opts.i18n || {}
+    
     menu.reset();
     
     var title = opts.title || 'UNTITLED\n';
@@ -22,27 +25,27 @@ module.exports = function (opts) {
     (opts.names || []).forEach(function (name) {
         var isDone = (opts.completed || []).indexOf(name) >= 0;
         if (isDone) {
-            var m = '[COMPLETED]';
+            var m = i18n.completed;
             menu.add(
                 name
-                + Array(65 - m.length - name.length + 1).join(' ')
+                + Array(65 - vw.width(m) - vw.width(name) + 1).join(' ')
                 + m
             );
         }
         else menu.add(name);
     });
     menu.write('-----------------\n');
-    menu.add('HELP');
-    menu.add('EXIT');
+    menu.add(i18n.help);
+    menu.add(i18n.exit);
     
     menu.on('select', function (label) {
         var name = label.replace(/\s{2}.*/, '');
         
         menu.close();
-        if (name === 'EXIT') {
+        if (name === i18n.exit) {
             return emitter.emit('exit');
         }
-        else if (name === 'HELP') {
+        else if (name === i18n.help) {
             console.log();
             showHelp(opts);
         }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "split": "~0.3.0",
     "terminal-menu": "^2.1.1",
     "through2": "~0.5.1",
+    "visualwidth": "0.0.1",
     "x256": "~0.0.1"
   },
   "devDependencies": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -160,6 +160,8 @@ completed levels. default: `'~/.config/' + opts.name`
 
 * `opts.autoclose` - whether to close stdin automatically after the menu is
 shown
+* `opts.usage` - stream providing a different usage template (see below)
+* `opts.i18n` - object mapping to alternative language strings (see `/lib/en.json`)
 
 If `opts` is a string, it will be treated as the `opts.name`.
 


### PR DESCRIPTION
This PR adds the possibility to overwrite the English default Strings as requested in #6. The developer can pass an `i18n` object as an option mapping langage keys to alternative represenations (see `/lib/en.json` for english defaults). I didn't offer i18n support for strings that definetely seemed to be for developers only.

Also there is a new `usage` key which can be passed a readable stream providing an alternative usage template.

I used the `visualwidth` module to assure that it works for chinese character, too. However for chinese to fully work in adventure, `terminal-menu` has to be fixed (possibly with this https://github.com/substack/terminal-menu/pull/16)
