### PR TITLE
Add `autoclose` to control whether to close stdin after showing menu.

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,7 @@ Shop.prototype.showMenu = function (opts) {
     var menu = showMenu({
         fg: opts.fg,
         bg: opts.bg,
+        autoclose: typeof opts.autoclose === 'boolean' ? opts.autoclose : true,
         command: this.command,
         title: opts.title || this.name.toUpperCase(),
         names: this._adventures.map(function (x) { return x.name }),

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -52,7 +52,9 @@ module.exports = function (opts) {
     process.stdin.pipe(menu.createStream()).pipe(process.stdout);
     menu.once('close', function () {
         process.stdin.setRawMode(false);
-        process.stdin.end();
+        if (opts.autoclose) {
+            process.stdin.end();
+        }
     });
     emitter.close = function () { menu.close() };
     

--- a/readme.markdown
+++ b/readme.markdown
@@ -158,6 +158,9 @@ completed levels. default: `'~/.config/' + opts.name`
 * `opts.fg` - menu foreground color
 * `opts.bg` - menu background color
 
+* `opts.autoclose` - whether to close stdin automatically after the menu is
+shown
+
 If `opts` is a string, it will be treated as the `opts.name`.
 
 ## shop.add(name, fn)
@@ -178,6 +181,8 @@ The options are:
 * `opts.fg` - foreground color
 * `opts.bg` - background color
 * `opts.title` - menu title text
+* `opts.autoclose` - whether to close stdin automatically after the menu is
+shown
 
 ## shop.select(name)
 


### PR DESCRIPTION
This is needed to prevent closing of stdin when additional user input is
needed after selecting an option, such as confirming creation of some
local resources for an exercise.

The default is `true`, to keep the current default behaviour.